### PR TITLE
Autovot fixes and query subset generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs npm && \
 
 
 # Put bin on path
-RUN export PATH=$PATH:/bin
+ENV PATH=$PATH:/bin
+
+# Put venv on path
+ENV PATH=/site/env/bin:$PATH
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ RUN apt-get update && apt-get install -y \
     zlib1g-dev \
     ruby-sass \
     procps \
-    sox \
-    python-numpy
+    sox
 
 RUN add-apt-repository -y ppa:webupd8team/java && \
     apt-get update -y && \

--- a/pgdb/api.py
+++ b/pgdb/api.py
@@ -749,6 +749,12 @@ class EnrichmentViewSet(viewsets.ModelViewSet):
                 return Response(
                     'The subset cannot be empty.',
                     status=status.HTTP_400_BAD_REQUEST)
+            with CorpusContext(corpus.config) as c:
+                if c.hierarchy.has_token_subset(data.get('annotation_type', ''), data.get('subset_label', '')) or \
+                        c.hierarchy.has_type_subset(data.get('annotation_type', ''), data.get('subset_label', '')):
+                    return Response(
+                            "The {} subset already exists".format(data.get('subset_label', '')),
+                            status=status.HTTP_400_BAD_REQUEST)
             name = 'Encode {} subset'.format(label)
 
         #Stress pattern validation
@@ -1240,7 +1246,8 @@ class QueryViewSet(viewsets.ModelViewSet):
             return Response("Database is not running, cannot generate subset",
                     status=status.HTTP_400_BAD_REQUEST)
         with CorpusContext(corpus.config) as g:
-            if g.hierarchy.has_token_subset(request.data.get('annotation_type', ''), request.data.get('subset_name', '')):
+            if g.hierarchy.has_token_subset(request.data.get('annotation_type', ''), request.data.get('subset_name', '')) or \
+                    g.hierarchy.has_type_subset(request.data.get('annotation_type', ''), request.data.get('subset_name', '')):
                 return Response("There is already a subset with the name, {}".format(request.data.get('subset_name', '')), 
                         status=status.HTTP_400_BAD_REQUEST)
         query = models.Query.objects.filter(pk=pk, corpus=corpus).get()

--- a/pgdb/api.py
+++ b/pgdb/api.py
@@ -1224,7 +1224,7 @@ class QueryViewSet(viewsets.ModelViewSet):
         return Response(data)
 
     @detail_route(methods=['post'])
-    def generate_subset(self, request, pk=None, corpus_pk=None):
+    def generate_subset(self, request, pk=None, corpus_pk=None, *args, **kwargs):
         if isinstance(request.user, django.contrib.auth.models.AnonymousUser):
             return Response(status=status.HTTP_401_UNAUTHORIZED)
         corpus = models.Corpus.objects.get(pk=corpus_pk)
@@ -1232,9 +1232,17 @@ class QueryViewSet(viewsets.ModelViewSet):
             permissions = corpus.user_permissions.filter(user=request.user).all()
             if not len(permissions) or not permissions[0].can_view_detail:
                 return Response(status=status.HTTP_401_UNAUTHORIZED)
+        if not request.data.get('subset_name', ''):
+            return Response(
+                'The subset must have a name.',
+                status=status.HTTP_400_BAD_REQUEST)
         if not corpus.database.is_running:
             return Response("Database is not running, cannot generate subset",
                     status=status.HTTP_400_BAD_REQUEST)
+        with CorpusContext(corpus.config) as g:
+            if g.hierarchy.has_token_subset(request.data.get('annotation_type', ''), request.data.get('subset_name', '')):
+                return Response("There is already a subset with the name, {}".format(request.data.get('subset_name', '')), 
+                        status=status.HTTP_400_BAD_REQUEST)
         query = models.Query.objects.filter(pk=pk, corpus=corpus).get()
         if query is None:
             return Response(None, status=status.HTTP_400_BAD_REQUEST)

--- a/pgdb/models.py
+++ b/pgdb/models.py
@@ -1308,7 +1308,7 @@ class Query(models.Model):
             begin = time.time()
             with CorpusContext(self.corpus.config) as c:
                 q = self.generate_query_for_export(c)
-                q.create_subset(config["name"])
+                q.create_subset(config["subset_name"])
                 c.encode_hierarchy()
             config = self.config
             config['subset_encoded'] = True

--- a/pgdb/models.py
+++ b/pgdb/models.py
@@ -656,7 +656,7 @@ class Enrichment(models.Model):
                     return 'Must encode pauses'
             elif enrichment_type == 'vot':
                 #Check if utterances
-                if not True:
+                if not "utterance" in c.hierarchy.annotation_types:
                     return 'Must encode utterances'
             elif '_csv' in enrichment_type:
                 if config.get('path') is None:

--- a/pgdb/models.py
+++ b/pgdb/models.py
@@ -1293,6 +1293,33 @@ class Query(models.Model):
             self.running = False
             self.save()
 
+    def generate_subset(self):
+        self.running = True
+        config = self.config
+        config['subset_encoded'] = False
+        self.config = config
+        print(config)
+        self.save()
+        while os.path.exists(self.lockfile_path):
+            pass
+        with open(self.lockfile_path, 'w') as f:
+            pass
+        try:
+            begin = time.time()
+            with CorpusContext(self.corpus.config) as c:
+                q = self.generate_query_for_export(c)
+                q.create_subset(config["name"])
+                c.encode_hierarchy()
+            config = self.config
+            config['subset_encoded'] = True
+            self.config = config
+        except:
+            raise
+        finally:
+            os.remove(self.lockfile_path)
+            self.running = False
+            self.save()
+
     def export_query(self):
         self.running = True
         config = self.config

--- a/pgdb/models.py
+++ b/pgdb/models.py
@@ -645,6 +645,9 @@ class Enrichment(models.Model):
                 annotation_type = config.get('annotation_type')
                 if not (annotation_type in c.hierarchy.annotation_types):
                     return 'Must encode {}'.format(annotation_type)
+                if c.hierarchy.has_token_subset(annotation_type, data.get('subset_label', '')) or \
+                        c.hierarchy.has_type_subset(annotation_type, data.get('subset_label', '')):
+                    return "The {} subset already exists".format(data.get('subset_label', ''))
             elif enrichment_type == 'syllables':
                 if not (c.hierarchy.has_type_subset('phone', config.get('phone_class', 'syllabic'))):
                     return 'Must encode {}'.format(config.get('phone_class', 'syllabic'))

--- a/pgdb/static/pgdb/components/query/query.service.js
+++ b/pgdb/static/pgdb/components/query/query.service.js
@@ -99,6 +99,11 @@ angular.module('pgdb.query')
             return base_url + corpus_id + '/query/' + id + '/export/';
         };
 
+        Query.generate_subset = function (corpus_id, id, query_data) {
+
+            return $http.post(base_url + corpus_id + '/query/' + id + '/generate_subset/', query_data);
+        };
+
         Query.generate_export = function (corpus_id, id, query_data) {
 
             return $http.post(base_url + corpus_id + '/query/' + id + '/generate_export/', query_data);

--- a/pgdb/static/pgdb/enrichment/vot/vot.html
+++ b/pgdb/static/pgdb/enrichment/vot/vot.html
@@ -31,11 +31,11 @@
 	</div>
         <div layout="row" flex layout-align="space-between none">
 		<md-input-container>
-			 <label>VOT Min:</label>
+			 <label>VOT Min(ms):</label>
 			 <input type="number" ng-model="enrichment.vot_min" min="0" max="500">
 		</md-input-container>
 		<md-input-container>
-			 <label>VOT Max:</label>
+			 <label>VOT Max(ms):</label>
 			 <input type="number" ng-model="enrichment.vot_max" min="0" max="500">
 		</md-input-container>
 		<md-button class="md-icon-button" aria-label="Help" ng-click="getHelp($event, 'vot_minmax')">
@@ -45,11 +45,11 @@
 	</div>
         <div layout="row" flex layout-align="space-between none">
 		<md-input-container>
-			 <label>Window Min:</label>
+			 <label>Window Min(ms):</label>
 			 <input type="number" ng-model="enrichment.window_min">
 		</md-input-container>
 		<md-input-container>
-			 <label>Window Max:</label>
+			 <label>Window Max(ms):</label>
 			 <input type="number" ng-model="enrichment.window_max">
 		</md-input-container>
 		<md-button class="md-icon-button" aria-label="Help" ng-click="getHelp($event, 'vot_minmax')">

--- a/pgdb/static/pgdb/enrichment/vot/vot.js
+++ b/pgdb/static/pgdb/enrichment/vot/vot.js
@@ -7,7 +7,7 @@ angular.module('vot', [
     djangoAuth.authenticationStatus(true).then(function () {
 	    Corpora.hierarchy($stateParams.corpus_id).then(function (res) {
 		$scope.hierarchy = res.data;
-		$scope.phone_subsets = $scope.hierarchy.subset_types.phone;
+		$scope.phone_subsets = $scope.hierarchy.subset_types.phone.concat($scope.hierarchy.subset_tokens.phone);
 	    });
     })
 

--- a/pgdb/static/pgdb/enrichment/vot/vot.js
+++ b/pgdb/static/pgdb/enrichment/vot/vot.js
@@ -59,7 +59,7 @@ angular.module('vot', [
     };
 
     $scope.help_text = {
-        stop_subset: 'This is the subset of phones that will have their VOTs calculated",
+        stop_subset: 'This is the subset of phones that will have their VOTs calculated',
 	classifier: 'This is the classifier that will be used. If unchecked, it will default to a classifier trained on voiceless word-initial VOTs in SOTC. The file format for classifier is a zip file containing both the pos and neg files from an AutoVOT trained classifier',
         vot_minmax: 'These values represent the minimum and maximum values of the VOT calculated. A minimum value of 15 ms will ensure that the difference between the closure and onset of voicing will be at least 15 ms.',
         window_minmax: 'This value represents the size of the window that will be analyzed for features. A minimum value of -30 ms means that the algorithm will begin looking for the closure 30 ms before the beginning of phone interval. A maximum value of 30 ms means that it will look at most 30 ms past the end of the phone interval',

--- a/pgdb/static/pgdb/enrichment/vot/vot.js
+++ b/pgdb/static/pgdb/enrichment/vot/vot.js
@@ -53,14 +53,16 @@ angular.module('vot', [
 
     $scope.help_titles = {
         stop_subset: 'Stops subset',
+	classifier: 'Classifier',
         vot_minmax: 'VOT Minimum and Maximum',
         window_minmax: 'Window Minimum and Maximum',
     };
 
     $scope.help_text = {
-        stop_subset: 'Stops subset',
-        vot_minmax: 'VOT Min',
-        window_minmax: 'WINDOW Max',
+        stop_subset: 'This is the subset of phones that will have their VOTs calculated",
+	classifier: 'This is the classifier that will be used. If unchecked, it will default to a classifier trained on voiceless word-initial VOTs in SOTC. The file format for classifier is a zip file containing both the pos and neg files from an AutoVOT trained classifier',
+        vot_minmax: 'These values represent the minimum and maximum values of the VOT calculated. A minimum value of 15 ms will ensure that the difference between the closure and onset of voicing will be at least 15 ms.',
+        window_minmax: 'This value represents the size of the window that will be analyzed for features. A minimum value of -30 ms means that the algorithm will begin looking for the closure 30 ms before the beginning of phone interval. A maximum value of 30 ms means that it will look at most 30 ms past the end of the phone interval',
     };
 
     $scope.setToDefault = function(voiced) {

--- a/pgdb/static/pgdb/query/query.html
+++ b/pgdb/static/pgdb/query/query.html
@@ -418,7 +418,7 @@
                        ng-show="!newQuery" ng-click="save_export()">Save CSV export file
             </md-button>
             <md-button class="md-raised" ng-disabled="!newQuery && (query.running || refreshing || exporting)"
-                       ng-show="!newQuery" ng-click="generate_subset()">Generate subset from query
+                       ng-show="!newQuery" ng-click="generate_subset($event)">Generate subset from query
             </md-button>
         </div>
         <div ng-show="query.result_count==0 && !newQuery">

--- a/pgdb/static/pgdb/query/query.html
+++ b/pgdb/static/pgdb/query/query.html
@@ -417,6 +417,9 @@
             <md-button class="md-raised" ng-disabled="!query.export_available || exporting"
                        ng-show="!newQuery" ng-click="save_export()">Save CSV export file
             </md-button>
+            <md-button class="md-raised" ng-disabled="!newQuery && (query.running || refreshing || exporting)"
+                       ng-show="!newQuery" ng-click="generate_subset()">Generate subset from query
+            </md-button>
         </div>
         <div ng-show="query.result_count==0 && !newQuery">
             <span>No results found</span>

--- a/pgdb/static/pgdb/query/query.js
+++ b/pgdb/static/pgdb/query/query.js
@@ -499,18 +499,31 @@ angular.module('query', [
 
         };
 
-        $scope.generate_subset = function () {
+        $scope.generate_subset = function(ev) {
             $scope.exporting = true;
             console.log($scope.query)
-            Query.generate_subset($stateParams.corpus_id, $stateParams.query_id, $scope.query).then(function (res) {
-                $scope.query = res.data;
-                getData();
-
-            }).catch(function (res) {
-                console.log('error!', res);
-            });
-
-
+	    var name_prompt = $mdDialog.prompt()
+	    	                       .parent(angular.element(document.querySelector('html')))
+	    	                       .title("Subset name")
+	    	                       .textContent("Choose a name for the new subset")
+		                       .initialValue($scope.query.subset_name ? $scope.query.subset_name : $scope.query.name)
+		                       .targetEvent(ev)
+		                       .required(true)
+	    	                       .ok("Okay")
+		                       .cancel("Cancel subset encoding")
+	    $mdDialog.show(name_prompt).then(function(subset_name) {
+		    $scope.query.subset_name = subset_name;
+		    Query.generate_subset($stateParams.corpus_id, $stateParams.query_id, $scope.query).then(function (res) {
+			$scope.query = res.data;
+			getData();
+		    }).catch(function (res) {
+			console.log('error!', res);
+		    });
+	    }, function() {
+		    console.log("Subset encoding canceled");
+		    $scope.exporting = false;
+	    }
+	    );
         };
 
 

--- a/pgdb/static/pgdb/query/query.js
+++ b/pgdb/static/pgdb/query/query.js
@@ -509,7 +509,7 @@ angular.module('query', [
 		                       .initialValue($scope.query.subset_name ? $scope.query.subset_name : $scope.query.name)
 		                       .targetEvent(ev)
 		                       .required(true)
-	    	                       .ok("Okay")
+	    	                       .ok("Use this name")
 		                       .cancel("Cancel subset encoding")
 	    $mdDialog.show(name_prompt).then(function(subset_name) {
 		    $scope.query.subset_name = subset_name;

--- a/pgdb/static/pgdb/query/query.js
+++ b/pgdb/static/pgdb/query/query.js
@@ -516,8 +516,10 @@ angular.module('query', [
 		    Query.generate_subset($stateParams.corpus_id, $stateParams.query_id, $scope.query).then(function (res) {
 			$scope.query = res.data;
 			getData();
+		        $scope.exporting = false;
 		    }).catch(function (res) {
 			console.log('error!', res);
+			$scope.exporting = false;
 		    });
 	    }, function() {
 		    console.log("Subset encoding canceled");

--- a/pgdb/static/pgdb/query/query.js
+++ b/pgdb/static/pgdb/query/query.js
@@ -499,6 +499,20 @@ angular.module('query', [
 
         };
 
+        $scope.generate_subset = function () {
+            $scope.exporting = true;
+            console.log($scope.query)
+            Query.generate_subset($stateParams.corpus_id, $stateParams.query_id, $scope.query).then(function (res) {
+                $scope.query = res.data;
+                getData();
+
+            }).catch(function (res) {
+                console.log('error!', res);
+            });
+
+
+        };
+
 
         $scope.save_export = function () {
             $scope.exporting = true;
@@ -712,6 +726,7 @@ angular.module('query', [
                     $scope.getHierarchy();
                     console.log('GOT QUERY getdata');
                     console.log($scope.query);
+		    console.log($scope.hierarchy);
                     if ($scope.exporting){
                         if (!$scope.query.running && $scope.query.export_available) {
                             $scope.exporting = false;

--- a/pgdb/tasks.py
+++ b/pgdb/tasks.py
@@ -33,6 +33,10 @@ def run_query_export_task(query_id):
     query = Query.objects.get(pk=query_id)
     query.export_query()
 
+@shared_task
+def run_query_generate_subset_task(query_id):
+    query = Query.objects.get(pk=query_id)
+    query.generate_subset()
 
 @shared_task
 def run_enrichment_task(enrichment_id):


### PR DESCRIPTION
This PR fixes a couple minor issues with autovot, and additionally adds the ability to encode token type subsets using the query interface. 

Currently you can only use these token subsets with autovot(which supports both token and type subsets). I'm hesitant to add the token subsets to any other enrichments, since token and type subsets are represented differently in PolyglotDB. 